### PR TITLE
urlによって使うセッションを変更する

### DIFF
--- a/laravel/app/Http/Middleware/SessionCookieSwitcher.php
+++ b/laravel/app/Http/Middleware/SessionCookieSwitcher.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SessionCookieSwitcher
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        // リクエストのパスに応じてセッションクッキー名を設定
+        if ($request->is('warehouse/*')) {
+            config(['session.cookie' => config('session.warehouse_cookie')]);
+        }
+        elseif ($request->is('agency/*')) {
+            config(['session.cookie' => config('session.agency_cookie')]);
+        }
+
+        return $next($request);
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -19,14 +19,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        // ページによって使うセッションを変える
-        // お互いのページには影響がないため大丈夫らしい(情報が少ないため不安が残る)
-        if (request()->is('warehouse/*')) {
-            config(['session.cookie' => config('session.warehouse_cookie')]);
-        }
 
-        if (request()->is('agency/*')) {
-            config(['session.cookie' => config('session.agency_cookie')]);
-        }
     }
 }

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -19,6 +19,14 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        // ページによって使うセッションを変える
+        // お互いのページには影響がないため大丈夫らしい(情報が少ないため不安が残る)
+        if (request()->is('warehouse/*')) {
+            config(['session.cookie' => config('session.warehouse_cookie')]);
+        }
+
+        if (request()->is('agency/*')) {
+            config(['session.cookie' => config('session.agency_cookie')]);
+        }
     }
 }

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -4,6 +4,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Support\Facades\Route;
+use App\Http\Middleware\SessionCookieSwitcher;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -24,6 +25,8 @@ return Application::configure(basePath: dirname(__DIR__))
         },
     )
     ->withMiddleware(function (Middleware $middleware) {
+        $middleware->append(SessionCookieSwitcher::class);
+
         $middleware->redirectUsersTo(function ($request) {
             // 倉庫系のurlでログイン済みの場合、未ログインユーザーのみアクセスできるページにアクセスしようとすると弾く
             if ($request->is('warehouse*')) {

--- a/laravel/config/session.php
+++ b/laravel/config/session.php
@@ -132,6 +132,9 @@ return [
         Str::slug(env('APP_NAME', 'laravel'), '_').'_session'
     ),
 
+    'warehouse_cookie' => "warehouse_session",
+    'agency_cookie' => "agency_session",
+
     /*
     |--------------------------------------------------------------------------
     | Session Cookie Path


### PR DESCRIPTION
# 問題点
代理店、倉庫ユーザーの両方ログインできるユーザーの場合、片方をログアウトするともう片方もログアウトされてしまう。

# 原因
同じセッションを使っていたのが問題

# 対処
urlによって個別のセッションを発行するようにした。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - リクエストパスに基づいて異なるセッションクッキーを設定する機能を追加しました。特定のパス（`warehouse/*` または `agency/*`）に応じて、セッション管理が柔軟に行えるようになりました。
  - 新しいミドルウェア `SessionCookieSwitcher` が追加され、リクエストのコンテキストに応じたセッションクッキーの動的管理が可能になりました。

- **設定変更**
  - 新しいセッションクッキー設定 (`warehouse_cookie` および `agency_cookie`) が追加され、異なるコンテキストに対応したセッション管理が可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->